### PR TITLE
Adding the package api-handler

### DIFF
--- a/packages/api-handler/package.json
+++ b/packages/api-handler/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@orpheus/api-handler",
+  "version": "1.0.0",
+  "description": "A simple API handler that should do all the repetitive req,res tasks",
+  "main": "dist/src/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "build:alias": "tsc-alias -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "build:dts": "tsc --emitDeclarationOnly",
+    "build:all": "yarn clean && yarn build && yarn build:alias && rollup -c rollup.config.mjs &&  find ./dist/src -type f -name '*.d.ts' -delete"
+  },
+  "author": "Soumil Singh",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "rollup": "^4.43.0",
+    "rollup-plugin-dts": "^6.2.1"
+  }
+}

--- a/packages/api-handler/rollup.config.mjs
+++ b/packages/api-handler/rollup.config.mjs
@@ -1,0 +1,11 @@
+import dts from 'rollup-plugin-dts'
+import { defineConfig } from 'rollup'
+
+export default defineConfig({
+  input: 'dist/src/index.d.ts', // entry .d.ts file
+  output: {
+    file: 'dist/index.d.ts',      // final single declaration file
+    format: 'es',
+  },
+  plugins: [dts()],
+})

--- a/packages/api-handler/src/api-handler.ts
+++ b/packages/api-handler/src/api-handler.ts
@@ -1,0 +1,59 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express'
+import { ApiResponse } from '@/types'
+
+export interface HandlerResult<T> {
+  data: T | null
+  message?: string
+  statusCode: number
+  success?: boolean
+}
+
+/**
+ * Wraps an async route handler and automatically formats the response.
+ * Handles successful responses with consistent `ApiResponse` shape,
+ * and forwards thrown errors to the global error handler.
+ *
+ * This helps you:
+ * - Eliminate repeated `res.status(...).json(...)` calls
+ * - Return consistent success response format
+ * - Let you throw `ApiError`s and catch them globally
+ *
+ * @template T The type of the data to return in the response.
+ * @param fn The actual async handler function that returns `HandlerResult<T>`.
+ * @returns An Express `RequestHandler` ready to be used as a controller.
+ *
+ * @example
+ * ```ts
+ * const getUser = apiHandler(async (req) => {
+ *   const user = await findUser(req.params.id)
+ *   if (!user) throw new ApiError(status.NOT_FOUND, "User not found")
+ *   return { data: user, statusCode: status.OK }
+ * })
+ * ```
+ */
+export function apiHandler<T = unknown>(
+  fn: (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => Promise<HandlerResult<T>>
+): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const { data, message, statusCode, success } = await fn(req, res, next)
+
+      // If response was already sent (e.g., early stream), skip
+      if (res.headersSent) return
+
+      const response: ApiResponse<T> = {
+        success: success ?? true,
+        data,
+        message: message ?? null,
+      }
+
+      res.status(statusCode).json(response)
+    } catch (err) {
+      if (!res.headersSent) next(err) // Delegate to globalApiErrorHandler
+    }
+  }
+}

--- a/packages/api-handler/src/index.ts
+++ b/packages/api-handler/src/index.ts
@@ -1,0 +1,2 @@
+export * from '@/types'
+export * from './api-handler'

--- a/packages/api-handler/src/types/api-response.ts
+++ b/packages/api-handler/src/types/api-response.ts
@@ -1,0 +1,6 @@
+export interface ApiResponse<T = unknown> {
+  success: boolean
+  data: T | null
+  message?: string | null
+  error?: string | null
+}

--- a/packages/api-handler/src/types/index.ts
+++ b/packages/api-handler/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './api-response'
+export * from './paginated-api-response'

--- a/packages/api-handler/src/types/paginated-api-response.ts
+++ b/packages/api-handler/src/types/paginated-api-response.ts
@@ -1,0 +1,11 @@
+import { ApiResponse } from './api-response'
+
+export interface PaginatedData<T> {
+  items: T[]
+  page: number
+  limit: number
+  totalRecords: number
+  totalPages: number
+}
+
+export type PaginatedApiResponse<T = unknown> = ApiResponse<PaginatedData<T>>

--- a/packages/api-handler/tsconfig.json
+++ b/packages/api-handler/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "declaration": true,
+    "declarationDir": "dist"
+    // "emitDeclarationOnly": true
+  },
+  "include": ["**/*.ts", "package.json", "README.md"]
+}

--- a/shared/error-utils/src/handlers/error.handler.ts
+++ b/shared/error-utils/src/handlers/error.handler.ts
@@ -21,13 +21,17 @@ export const globalApiErrorHandler: ErrorRequestHandler = (
   next: NextFunction
 ) => {
   // console.error(err.stack) // Log the error stack trace for debugging
+  // Prevent sending response if headers are already sent
+  if (res.headersSent) {
+    return next(err)
+  }
 
   // If the error is an instance of ApiError, use its properties
   if (err instanceof ApiError) {
     res.status(err.statusCode).json({
       success: false,
       message: err.message,
-      error: process.env.NODE_ENV === 'development' ? err : {}, // Send detailed error in development mode
+      error: process.env.NODE_ENV === 'development' ? err : null, // Send detailed error in development mode
     })
     return
   }

--- a/shared/error-utils/src/handlers/error.handler.ts
+++ b/shared/error-utils/src/handlers/error.handler.ts
@@ -22,9 +22,7 @@ export const globalApiErrorHandler: ErrorRequestHandler = (
 ) => {
   // console.error(err.stack) // Log the error stack trace for debugging
   // Prevent sending response if headers are already sent
-  if (res.headersSent) {
-    return next(err)
-  }
+  if (res.headersSent) return
 
   // If the error is an instance of ApiError, use its properties
   if (err instanceof ApiError) {


### PR DESCRIPTION
### New Package: API Handler
This package allows for automatic client response serving by providing a wrapper over the typical express request response cycle. Following types/interfaces added:
- ApiResponse
- PageinatedApiResponse

The Handler handles error by providing it to the next handler so that it can be passed of to the global api error handler which takes care of all error response handling via the ApiError object

_Minor Patch on error-utils:_
- Global API Error handler now checks for res.headersent before response handling, in case error response is directly handled by the service or at some other higher level. This avoids the pesky runtime error often associated with the global handler